### PR TITLE
Edit prompts

### DIFF
--- a/align_app/app/ui.py
+++ b/align_app/app/ui.py
@@ -285,29 +285,59 @@ class ScenarioLayout:
             html.Li("{{choice.unstructured}}", v_for=(f"choice in {scenario}.choices"))
 
 
-class EditableScenarioLayout:
-    def __init__(self):
-        html.Div("Situation", classes="text-h6")
-        vuetify3.VTextarea(
-            v_model=("edited_scenario_text",),
-            auto_grow=True,
-            rows=3,
-            hide_details="auto",
-        )
-        html.Div("Choices", classes="text-h6 pt-4")
-        with html.Div(classes="ml-4"):
-            with html.Div(
-                v_for=("(choice, index) in edited_choices",),
-                key=("index",),
-                classes="d-flex align-center mb-2",
-            ):
-                html.Span("{{String.fromCharCode(65 + index)}}.", classes="mr-2")
-                vuetify3.VTextarea(
-                    v_model=("edited_choices[index]",),
-                    auto_grow=True,
-                    rows=1,
-                    hide_details="auto",
-                    density="compact",
+class EditableScenarioLayout(html.Div):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        with self:
+            html.Div("Situation", classes="text-h6")
+            vuetify3.VTextarea(
+                v_model=("edited_scenario_text",),
+                auto_grow=True,
+                rows=3,
+                hide_details="auto",
+            )
+            html.Div("Choices", classes="text-h6 pt-4")
+            with html.Div(classes="ml-4"):
+                with html.Ul(classes="pa-0", style="list-style: none"):
+                    with html.Li(
+                        v_for=("(choice, index) in edited_choices",),
+                        key=("index",),
+                        classes="d-flex align-center mb-2",
+                    ):
+                        html.Span(
+                            "{{String.fromCharCode(65 + index)}}.", classes="mr-2"
+                        )
+                        vuetify3.VTextarea(
+                            model_value=("edited_choices[index]",),
+                            update_modelValue=(
+                                self.server.controller.update_choice,
+                                "[index, $event]",
+                            ),
+                            auto_grow=True,
+                            rows=1,
+                            hide_details="auto",
+                            density="compact",
+                            classes="flex-grow-1",
+                        )
+                        with vuetify3.VBtn(
+                            icon=True,
+                            size="small",
+                            classes="ml-2",
+                            disabled=("edited_choices.length <= 2",),
+                            click=(
+                                self.server.controller.delete_choice,
+                                "[index]",
+                            ),
+                            v_if=("max_choices > 2",),
+                        ):
+                            vuetify3.VIcon("mdi-close", size="small")
+                vuetify3.VBtn(
+                    "Add Choice",
+                    click=self.server.controller.add_choice,
+                    variant="outlined",
+                    size="small",
+                    classes="mt-2",
+                    v_if=("edited_choices.length < max_choices && max_choices > 2",),
                 )
 
 
@@ -462,7 +492,7 @@ class EditableScenarioPanel(vuetify3.VExpansionPanel):
                 EditableScenarioLayout()
 
 
-class PromptInput(vuetify3.VCard):
+class PromptInput(html.Div):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         with self:

--- a/align_app/app/ui.py
+++ b/align_app/app/ui.py
@@ -275,9 +275,19 @@ class SystemPrompt:
 
 
 class ScenarioLayout:
-    def __init__(self, scenario):
+    def __init__(self, scenario, editable=False):
         html.Div("Situation", classes="text-h6")
-        html.P(f"{{{{{scenario}.display_state}}}}")
+        if editable:
+            vuetify3.VTextarea(
+                v_model=("edited_scenario_text",),
+                auto_grow=True,
+                rows=3,
+                hide_details="auto",
+                variant="outlined",
+                density="compact",
+            )
+        else:
+            html.P(f"{{{{{scenario}.display_state}}}}")
         html.Div(
             "Characters",
             classes="text-h6 pt-4",
@@ -309,7 +319,7 @@ class Scenario:
     class Text:
         def __init__(self):
             def run_content():
-                ScenarioLayout("runs[id].prompt.scenario")
+                ScenarioLayout("runs[id].prompt.scenario", editable=False)
 
             RowWithLabel(run_content=run_content)
 
@@ -419,7 +429,7 @@ class ResultsComparison(html.Div):
 
 
 class ScenarioPanel(vuetify3.VExpansionPanel):
-    def __init__(self, scenario, **kwargs):
+    def __init__(self, scenario, editable=False, **kwargs):
         super().__init__(**kwargs)
         with self:
             with vuetify3.VExpansionPanelTitle():
@@ -429,7 +439,7 @@ class ScenarioPanel(vuetify3.VExpansionPanel):
                         f"{{{{{scenario}.full_state.unstructured}}}}",
                     )
             with vuetify3.VExpansionPanelText():
-                ScenarioLayout(scenario)
+                ScenarioLayout(scenario, editable=editable)
 
 
 class PromptInput(vuetify3.VCard):
@@ -443,7 +453,7 @@ class PromptInput(vuetify3.VCard):
                     v_model=("prompt_scenario_id",),
                 )
                 with vuetify3.VExpansionPanels(multiple=True, variant="accordion"):
-                    ScenarioPanel("prompt_scenario")
+                    ScenarioPanel("prompt_scenario", editable=True)
 
                 vuetify3.VSelect(
                     classes="mt-6",

--- a/align_app/app/ui.py
+++ b/align_app/app/ui.py
@@ -642,6 +642,12 @@ class AlignLayout(SinglePageLayout):
                 if reload:
                     with vuetify3.VBtn(icon=True, click=reload):
                         vuetify3.VIcon("mdi-refresh")
+                with vuetify3.VBtn(
+                    icon=True,
+                    click="utils.download('align-app-runs.json', runs_json || '[]', 'application/json')",
+                    disabled=("Object.keys(runs).length === 0",),
+                ):
+                    vuetify3.VIcon("mdi-download")
                 with vuetify3.VBtn(icon=True, click=self.server.controller.reset_state):
                     vuetify3.VIcon("mdi-undo")
 

--- a/align_app/app/unordered_object.py
+++ b/align_app/app/unordered_object.py
@@ -2,11 +2,11 @@ from trame.widgets import html, vuetify3
 
 
 class ValueWithProgressBar(html.Span):
-    def __init__(self, value_expression, decimals=2, **kwargs):
+    def __init__(self, value_expression, decimals=2, max_value=1, **kwargs):
         super().__init__(**kwargs)
         with self:
             vuetify3.VProgressLinear(
-                model_value=(f"{value_expression} * 100",),
+                model_value=(f"({value_expression} / {max_value}) * 100",),
                 height="10",
                 readonly=True,
                 style=("display: inline-block; width: 80px;"),


### PR DESCRIPTION
<img width="3840" height="2160" alt="Screenshot 2025-08-15 102207" src="https://github.com/user-attachments/assets/99d2dbc6-af20-46ef-b3e9-436814dafcc2" />

If a choice is edited, make `action_type` unknown to avoid matching one of these remappers?
https://github.com/ITM-Kitware/align-system/blob/main/align_system/utils/adm_utils.py