### PR TITLE
feat: add support for loading custom ADM configs from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ Then visit http://localhost:8080
 The first time you run a model, it will take some time for the HuggingFace transformers library to
 download the model.
 
+### Run with Custom ADM Configs
+
+You can load custom ADM configurations from align-system using the `--decider` flag. This supports both:
+
+- **Composable ADM configs** (e.g., `adm/outlines_regression_aligned.yaml`)
+- **Full experiment configs** with `@package _global_` directive (e.g., `phase2_july_collab/pipeline_baseline.yaml`)
+
+```console
+# Load a composable ADM config
+poetry run align-app --decider adm/phase2_pipeline_zeroshot_comparative_regression.yaml
+
+# Load a full experiment config
+poetry run align-app --decider phase2_july_collab/pipeline_fewshot_comparative_regression_20icl_live_eval_test.yaml
+
+# Load multiple configs
+poetry run align-app --decider adm/phase2_pipeline_zeroshot_comparative_regression.yaml phase2_july_collab/pipeline_baseline.yaml
+
+# Load configs using absolute paths
+poetry run align-app --decider /path/to/align-system/configs/adm/phase2_pipeline_zeroshot_comparative_regression.yaml
+```
+
 ### Optionally Configure Network Port or Host
 
 The web server is from Trame. To configure the port, use the `--port` arg

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Example [Mistral-AI's](https://huggingface.co/mistralai/Mistral-7B-v0.3)
 export HF_TOKEN=<your token obtained from Hugging Face website>
 ```
 
-### Run the Application
+## Run the Application
 
 ```console
 poetry run align-app
@@ -49,23 +49,20 @@ download the model.
 
 ### Run with Custom ADM Configs
 
-You can load custom ADM configurations from align-system using the `--decider` flag. This supports both:
+You can load custom ADM configurations from align-system using the `--deciders` flag. This supports both:
 
 - **Composable ADM configs** (e.g., `adm/outlines_regression_aligned.yaml`)
 - **Full experiment configs** with `@package _global_` directive (e.g., `phase2_july_collab/pipeline_baseline.yaml`)
 
 ```console
 # Load a composable ADM config
-poetry run align-app --decider adm/phase2_pipeline_zeroshot_comparative_regression.yaml
+poetry run align-app --deciders adm/phase2_pipeline_zeroshot_comparative_regression.yaml
 
 # Load a full experiment config
-poetry run align-app --decider phase2_july_collab/pipeline_fewshot_comparative_regression_20icl_live_eval_test.yaml
+poetry run align-app --deciders phase2_july_collab/pipeline_fewshot_comparative_regression_20icl_live_eval_test.yaml
 
 # Load multiple configs
-poetry run align-app --decider adm/phase2_pipeline_zeroshot_comparative_regression.yaml phase2_july_collab/pipeline_baseline.yaml
-
-# Load configs using absolute paths
-poetry run align-app --decider /path/to/align-system/configs/adm/phase2_pipeline_zeroshot_comparative_regression.yaml
+poetry run align-app --deciders adm/phase2_pipeline_zeroshot_comparative_regression.yaml phase2_july_collab/pipeline_baseline.yaml
 ```
 
 ### Optionally Configure Network Port or Host
@@ -73,7 +70,7 @@ poetry run align-app --decider /path/to/align-system/configs/adm/phase2_pipeline
 The web server is from Trame. To configure the port, use the `--port` arg
 
 ```console
-poetry run align-app --port 8081
+poetry run align-app --port 8888
 ```
 
 To expose the server to the network run with the `--host` arg
@@ -81,6 +78,26 @@ To expose the server to the network run with the `--host` arg
 ```console
 poetry run align-app --host 0.0.0.0
 ```
+
+### Accessing Web Page via SSH Tunnel
+
+If you're running the app on a remote server, you can access it locally through an SSH tunnel:
+
+1. On the remote server, run the app with your desired port:
+
+```console
+poetry run align-app --port 8888
+```
+
+2. On your local machine, set up an SSH tunnel:
+
+```console
+ssh -N -f -L 8888:127.0.0.1:8888 your-remote-host
+```
+
+3. Access the app in your browser at `http://localhost:8888`
+
+The `-L` flag creates a local port forward, `-N` tells SSH not to execute a remote command, and `-f` runs SSH in the background.
 
 ## Development
 
@@ -95,3 +112,13 @@ pre-commit install
 ### Release
 
 Merge a PR to `main` with semantic commit messages.
+
+## Using Custom align-system Code
+
+To run align-app with your local development version of align-system:
+
+```console
+cd align-app
+poetry run pip install -e ../align-system
+poetry run align-app
+```

--- a/align_app/adm/decider.py
+++ b/align_app/adm/decider.py
@@ -17,10 +17,10 @@ def _get_process_manager():
     return _decider
 
 
-async def get_decision(prompt):
-    """Get a decision for a prompt"""
+async def get_decision(context):
+    """Get a decision for a context"""
     process_manager = _get_process_manager()
-    return await process_manager.get_decision(prompt)
+    return await process_manager.get_decision(context)
 
 
 # Ensure the subprocess is cleaned up

--- a/align_app/adm/decider_registry.py
+++ b/align_app/adm/decider_registry.py
@@ -1,0 +1,61 @@
+from functools import partial
+from collections import namedtuple
+from . import adm_core
+
+
+DeciderRegistry = namedtuple(
+    "DeciderRegistry",
+    [
+        "get_dataset_decider_configs",
+        "get_system_prompt",
+        "get_base_decider_config",
+        "resolve_decider_config",
+        "prepare_context",
+        "create_adm",
+        "instantiate_adm",
+        "get_all_deciders",
+    ],
+)
+
+
+def create_decider_registry(config_paths=[]):
+    """
+    Takes config paths and returns a DeciderRegistry namedtuple
+    with all_deciders pre-bound using partial application.
+    """
+    all_deciders = adm_core.get_all_deciders(config_paths)
+
+    def create_adm_wrapper(
+        llm_backbone="", decider=None, baseline=True, scenario_id=None
+    ):
+        config = adm_core.get_base_decider_config(
+            scenario_id, decider, baseline, all_deciders
+        )
+        return adm_core.create_adm(config, llm_backbone)
+
+    def instantiate_adm_wrapper(
+        llm_backbone="", decider=None, baseline=True, scenario_id=None
+    ):
+        config = adm_core.get_base_decider_config(
+            scenario_id, decider, baseline, all_deciders
+        )
+        return adm_core.instantiate_adm(config, llm_backbone)
+
+    return DeciderRegistry(
+        get_dataset_decider_configs=partial(
+            adm_core.get_dataset_decider_configs, all_deciders=all_deciders
+        ),
+        get_system_prompt=partial(
+            adm_core.get_system_prompt, all_deciders=all_deciders
+        ),
+        get_base_decider_config=partial(
+            adm_core.get_base_decider_config, all_deciders=all_deciders
+        ),
+        resolve_decider_config=partial(
+            adm_core.resolve_decider_config, all_deciders=all_deciders
+        ),
+        prepare_context=partial(adm_core.prepare_context, all_deciders=all_deciders),
+        create_adm=create_adm_wrapper,
+        instantiate_adm=instantiate_adm_wrapper,
+        get_all_deciders=lambda: all_deciders,
+    )

--- a/align_app/adm/hydra_config_loader.py
+++ b/align_app/adm/hydra_config_loader.py
@@ -1,0 +1,127 @@
+"""
+Unified Hydra configuration loader for ADM configs.
+
+This module provides a single, unified loader that handles both regular ADM configs
+and experiment configs with @package _global_ directives.
+"""
+
+from pathlib import Path
+from typing import Dict, Any, Optional, cast
+from functools import lru_cache
+import logging
+
+import align_system
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+from omegaconf import OmegaConf
+
+logger = logging.getLogger(__name__)
+
+
+def _find_config_file(config_path: str, config_dir_path: Path) -> Path | None:
+    config_path_obj = Path(config_path)
+
+    if config_path_obj.exists():
+        return config_path_obj
+
+    if config_path_obj.is_absolute() and config_path_obj.exists():
+        return config_path_obj
+
+    search_locations = [
+        config_dir_path / config_path,
+        config_dir_path / f"adm/{config_path}",
+        config_dir_path / f"experiment/{config_path}",
+    ]
+
+    for test_path in search_locations:
+        if test_path.exists():
+            return test_path
+
+    experiment_dir = config_dir_path / "experiment"
+    if experiment_dir.exists():
+        for subdir in experiment_dir.iterdir():
+            if subdir.is_dir():
+                test_file = subdir / config_path
+                if test_file.exists():
+                    return test_file
+
+    return config_dir_path / config_path
+
+
+def _get_hydra_config_path(config_file: Path, config_dir_path: Path) -> str:
+    """Get the config path for Hydra - relative path without extension."""
+    try:
+        relative_path = config_file.relative_to(config_dir_path)
+        return relative_path.with_suffix("").as_posix()
+    except ValueError:
+        return config_file.stem
+
+
+@lru_cache(maxsize=32)
+def load_adm_config(
+    config_path: str,
+    config_dir: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Universal config loader for ADM configs with caching.
+
+    Creates a fresh Hydra context for each unique configuration to avoid
+    state pollution. Uses LRU cache to maintain performance for repeated loads.
+
+    The config type (experiment vs regular) is determined by the presence of
+    '# @package _global_' directive in the YAML file, NOT by the path.
+
+    Args:
+        config_path: Path to config file or config name (e.g., "adm/pipeline_baseline")
+        config_dir: Base config directory (auto-detected if None)
+
+    Returns:
+        Loaded configuration dictionary
+    """
+    if config_dir is None:
+        try:
+            config_dir = str(Path(align_system.__file__).parent / "configs")
+        except ImportError:
+            raise ValueError(
+                "Could not auto-detect config_dir. Please provide it explicitly."
+            )
+
+    config_dir_path = Path(config_dir)
+    config_file = _find_config_file(config_path, config_dir_path)
+
+    if not config_file or not config_file.exists():
+        raise ValueError(f"Could not find config file: {config_path}")
+
+    hydra_config_path = _get_hydra_config_path(config_file, config_dir_path)
+
+    with open(config_file, "r") as f:
+        first_line = f.readline().strip()
+        is_experiment_config = first_line == "# @package _global_"
+
+    if is_experiment_config:
+        hydra_path = Path(hydra_config_path)
+        if hydra_path.parts and hydra_path.parts[0] == "experiment":
+            hydra_config_path = Path(*hydra_path.parts[1:]).as_posix()
+
+    logger.debug(
+        f"Loading config: path={config_path}, "
+        f"hydra_config_path={hydra_config_path}, "
+        f"is_experiment={is_experiment_config}"
+    )
+
+    hydra_instance = GlobalHydra.instance()
+    if hydra_instance.is_initialized():
+        hydra_instance.clear()
+
+    with initialize_config_dir(str(config_dir_path), version_base=None):
+        if is_experiment_config:
+            cfg = compose(
+                config_name="action_based",
+                overrides=[f"+experiment={hydra_config_path}"],
+            )
+        else:
+            cfg = compose(config_name=hydra_config_path)
+
+        result = OmegaConf.to_container(cfg)
+        assert isinstance(result, dict), "Config must be a dictionary"
+        return cast(Dict[str, Any], result)

--- a/align_app/app/core.py
+++ b/align_app/app/core.py
@@ -4,6 +4,7 @@ from . import ui
 from ..adm.decider import get_decision
 from .prompt import PromptController
 from ..utils.utils import get_id
+from ..adm.adm_core import register_experiment_deciders
 import json
 
 
@@ -11,7 +12,25 @@ import json
 class AlignApp:
     def __init__(self, server=None):
         self.server = get_server(server, client_type="vue3")
+
+        self.server.cli.add_argument(
+            "--decider",
+            nargs="*",
+            help=(
+                "Paths to ADM or experiment config YAML files "
+                "like phase2_july_collab/pipeline_baseline.yaml"
+            ),
+        )
+
+        args, _ = self.server.cli.parse_known_args()
+        if args.decider:
+            register_experiment_deciders(args.decider)
+
         self._promptController = PromptController(self.server)
+
+        # Update deciders list if experiment configs were registered
+        if args.decider:
+            self._promptController.update_deciders()
         if self.server.hot_reload:
             self.server.controller.on_server_reload.add(self._build_ui)
 

--- a/align_app/app/core.py
+++ b/align_app/app/core.py
@@ -4,7 +4,6 @@ from . import ui
 from ..adm.decider import get_decision
 from .prompt import PromptController
 from ..utils.utils import get_id
-from ..adm.adm_core import register_experiment_deciders
 import json
 
 
@@ -14,7 +13,7 @@ class AlignApp:
         self.server = get_server(server, client_type="vue3")
 
         self.server.cli.add_argument(
-            "--decider",
+            "--deciders",
             nargs="*",
             help=(
                 "Paths to ADM or experiment config YAML files "
@@ -23,14 +22,8 @@ class AlignApp:
         )
 
         args, _ = self.server.cli.parse_known_args()
-        if args.decider:
-            register_experiment_deciders(args.decider)
 
-        self._promptController = PromptController(self.server)
-
-        # Update deciders list if experiment configs were registered
-        if args.decider:
-            self._promptController.update_deciders()
+        self._promptController = PromptController(self.server, args.deciders)
         if self.server.hot_reload:
             self.server.controller.on_server_reload.add(self._build_ui)
 
@@ -48,7 +41,6 @@ class AlignApp:
 
     @controller.set("reset_state")
     def reset_state(self):
-        self._promptController.reset()
         self.state.runs = {}
         self.state.runs_to_compare = []
 

--- a/align_app/app/prompt_logic.py
+++ b/align_app/app/prompt_logic.py
@@ -1,0 +1,140 @@
+"""Pure business logic and validation functions for prompt handling."""
+
+from typing import Dict, List, Any, cast
+import copy
+from ..adm.adm_core import get_prompt, Attribute
+
+
+def create_default_choice(index: int, text: str) -> Dict[str, Any]:
+    """Create a new choice with required fields for the alignment system."""
+    return {
+        "action_id": f"action-{index}",
+        "unstructured": text,
+        "action_type": "APPLY_TREATMENT",
+        "intent_action": True,
+        "parameters": {},
+        "justification": None,
+    }
+
+
+def compute_possible_attributes(
+    all_attrs: Dict, used_attrs: set, descriptions: Dict
+) -> List[Dict]:
+    """Compute available attributes not currently in use."""
+    return [
+        {
+            "value": key,
+            **details,
+            "description": descriptions.get(key, {}).get(
+                "description", f"No description available for {key}"
+            ),
+        }
+        for key, details in all_attrs.items()
+        if key not in used_attrs
+    ]
+
+
+def filter_valid_attributes(
+    attributes: List[Dict], valid_attributes: Dict
+) -> List[Dict]:
+    """Filter attributes to only include valid ones for the dataset."""
+    return [
+        attr
+        for attr in attributes
+        if attr["value"] in valid_attributes
+        and attr.get("possible_scores")
+        == valid_attributes[attr["value"]].get("possible_scores")
+    ]
+
+
+def select_initial_decider(deciders: List[Dict], current: str = "") -> str:
+    """Select the initial decider based on current selection and available options."""
+    if not deciders:
+        return ""
+
+    valid_values = [dm["value"] for dm in deciders]
+    if not current or current not in valid_values:
+        return deciders[0]["value"]
+    return current
+
+
+def build_choices_from_edited(
+    edited_choices: List[str], original_choices: List[Dict]
+) -> List[Dict]:
+    """Build new choices array with edited text."""
+    new_choices = []
+    for i, choice_text in enumerate(edited_choices):
+        if i < len(original_choices):
+            choice = copy.deepcopy(original_choices[i])
+            choice["unstructured"] = choice_text
+        else:
+            choice = create_default_choice(i, choice_text)
+        new_choices.append(choice)
+    return new_choices
+
+
+def get_max_alignment_attributes(decider_configs: Dict) -> int:
+    """Extract max alignment attributes from decider configs."""
+    if not decider_configs:
+        return 0
+    postures = decider_configs.get("postures", {})
+    if "aligned" in postures:
+        return postures["aligned"].get("max_alignment_attributes", 0)
+    return 0
+
+
+def get_llm_backbones_from_config(decider_configs: Dict) -> List[str]:
+    """Extract LLM backbones from decider config."""
+    if decider_configs and "llm_backbones" in decider_configs:
+        return decider_configs["llm_backbones"]
+    return ["N/A"]
+
+
+def build_prompt_context(
+    scenario_id: str,
+    llm_backbone: str,
+    decider: str,
+    attributes: List[Dict],
+    system_prompt: str,
+    edited_text: str,
+    edited_choices: List[str],
+    decider_registry,
+) -> Dict:
+    mapped_attributes: List[Attribute] = [
+        Attribute(type=a["value"], score=a["score"]) for a in attributes
+    ]
+
+    prompt_data = get_prompt(
+        scenario_id,
+        llm_backbone,
+        decider,
+        mapped_attributes,
+    )
+
+    scenario = prompt_data["scenario"]
+
+    resolved_config = decider_registry.resolve_decider_config(
+        scenario["scenario_id"],
+        prompt_data["decider_params"]["decider"],
+        prompt_data["alignment_target"],
+    )
+
+    original_choices = cast(List[Dict], scenario.get("choices", []))
+    edited_choices_list = build_choices_from_edited(edited_choices, original_choices)
+
+    updated_scenario = {
+        **scenario,
+        "display_state": edited_text,
+        "full_state": {
+            **cast(Dict, scenario.get("full_state", {})),
+            "unstructured": edited_text,
+        },
+        "choices": edited_choices_list,
+    }
+
+    return {
+        **prompt_data,
+        "system_prompt": system_prompt,
+        "resolved_config": resolved_config,
+        "scenario": updated_scenario,
+    }

--- a/align_app/app/ui.py
+++ b/align_app/app/ui.py
@@ -643,13 +643,16 @@ class AlignLayout(SinglePageLayout):
                     with vuetify3.VBtn(icon=True, click=reload):
                         vuetify3.VIcon("mdi-refresh")
                 with vuetify3.VBtn(
-                    icon=True,
                     click="utils.download('align-app-runs.json', runs_json || '[]', 'application/json')",
                     disabled=("Object.keys(runs).length === 0",),
+                    prepend_icon="mdi-file-download",
                 ):
-                    vuetify3.VIcon("mdi-download")
-                with vuetify3.VBtn(icon=True, click=self.server.controller.reset_state):
-                    vuetify3.VIcon("mdi-undo")
+                    html.Span("Export Runs")
+                with vuetify3.VBtn(
+                    click=self.server.controller.reset_state,
+                    prepend_icon="mdi-delete-sweep",
+                ):
+                    html.Span("Clear Runs")
 
             with layout.content:
                 with vuetify3.VContainer(fluid=True, classes="overflow-y-auto"):

--- a/align_app/app/ui.py
+++ b/align_app/app/ui.py
@@ -507,9 +507,9 @@ class PromptInput(html.Div):
 
                 vuetify3.VSelect(
                     classes="mt-6",
-                    label="Decision Maker",
-                    items=("decision_makers",),
-                    v_model=("decision_maker",),
+                    label="Decider",
+                    items=("deciders",),
+                    v_model=("decider",),
                     error_messages=("decider_messages",),
                 )
                 with html.Template(

--- a/tests/test_hydra_config_loader.py
+++ b/tests/test_hydra_config_loader.py
@@ -1,0 +1,103 @@
+from hydra.core.global_hydra import GlobalHydra
+
+from align_app.adm.hydra_config_loader import load_adm_config
+
+
+def test_load_regular_config():
+    result = load_adm_config("adm/pipeline_baseline.yaml")
+    assert "adm" in result
+    assert "instance" in result["adm"]
+    assert (
+        result["adm"]["instance"]["_target_"]
+        == "align_system.algorithms.pipeline_adm.PipelineADM"
+    )
+
+
+def test_load_experiment_config():
+    result = load_adm_config(
+        "experiment/phase2_july_collab/pipeline_fewshot_comparative_regression_20icl_live_eval_test.yaml"
+    )
+    assert "adm" in result
+    adm = result["adm"]
+    assert "step_definitions" in adm
+    if "regression_icl" in adm["step_definitions"]:
+        icl_settings = adm["step_definitions"]["regression_icl"]
+        if "icl_generator_partial" in icl_settings:
+            incontext = icl_settings["icl_generator_partial"].get(
+                "incontext_settings", {}
+            )
+            assert incontext.get("number") == 20
+
+
+def test_auto_detect_config_type():
+    regular_result = load_adm_config("adm/pipeline_baseline.yaml")
+    assert "adm" in regular_result
+
+    experiment_result = load_adm_config(
+        "experiment/phase2_july_collab/pipeline_fewshot_comparative_regression_20icl_live_eval_test.yaml"
+    )
+    assert "adm" in experiment_result
+
+
+def test_caching_behavior():
+    result1 = load_adm_config("adm/pipeline_baseline.yaml")
+    result2 = load_adm_config("adm/pipeline_baseline.yaml")
+    assert result1 == result2
+    assert result1 is result2
+
+
+def test_fresh_context_isolation():
+    if GlobalHydra.instance().is_initialized():
+        GlobalHydra.instance().clear()
+
+    result1 = load_adm_config("adm/pipeline_baseline.yaml")
+    assert not GlobalHydra.instance().is_initialized()
+
+    result2 = load_adm_config("adm/pipeline_random.yaml")
+    assert "adm" in result1
+    assert "adm" in result2
+
+
+def test_regular_vs_experiment_loading():
+    regular_cfg = load_adm_config("adm/pipeline_baseline.yaml")
+    assert "adm" in regular_cfg
+
+    exp_cfg = load_adm_config(
+        "experiment/phase2_july_collab/pipeline_fewshot_comparative_regression_20icl_live_eval_test.yaml"
+    )
+    assert "adm" in exp_cfg
+    assert len(exp_cfg.keys()) > len(regular_cfg.keys())
+
+
+def test_adm_core_integration_scenario():
+    config_path = "adm/pipeline_baseline.yaml"
+    full_cfg = load_adm_config(config_path)
+    adm_cfg = full_cfg.get("adm", {})
+    assert "instance" in adm_cfg
+    assert "step_definitions" in adm_cfg
+
+    full_cfg = load_adm_config(
+        "experiment/phase2_july_collab/pipeline_fewshot_comparative_regression_20icl_live_eval_test.yaml"
+    )
+    adm_cfg = full_cfg.get("adm", {})
+    assert "instance" in adm_cfg
+    assert "step_definitions" in adm_cfg
+
+
+def test_experiment_path_formats():
+    exp_file = "pipeline_fewshot_comparative_regression_20icl_live_eval_test.yaml"
+
+    test_cases = [
+        f"experiment/phase2_july_collab/{exp_file}",
+        f"phase2_july_collab/{exp_file}",
+    ]
+
+    results = []
+    for config_path in test_cases:
+        result = load_adm_config(config_path)
+        results.append(result)
+        assert "adm" in result
+
+    if len(results) > 1:
+        for i in range(1, len(results)):
+            assert results[0]["adm"].keys() == results[i]["adm"].keys()


### PR DESCRIPTION
Enables align-app to load ADM configurations directly from align-system via `--deciders` CLI argument. Supports both composable ADM configs and full experiment configs with `@package _global_` directives.

Example loading 2 ADMs, one from expirment configs, other from ADM configs
```
poetry run align-app -p 8888 --deciders adm/phase2_pipeline_kaleido.yaml phase2_july_collab/pipeline_fewshot_comparative_regression_20icl_live_eval_test.yaml
```

closes #55