### PR TITLE
Use VSnackbarQueue for stacking notifications

### DIFF
--- a/align_app/adm/decider/__init__.py
+++ b/align_app/adm/decider/__init__.py
@@ -1,11 +1,12 @@
 from align_utils.models import ADMResult, Decision, ChoiceInfo
 from .decider import MultiprocessDecider
-from .client import get_decision
+from .client import get_decision, is_model_cached
 from .types import DeciderParams
 
 __all__ = [
     "MultiprocessDecider",
     "get_decision",
+    "is_model_cached",
     "DeciderParams",
     "ADMResult",
     "Decision",

--- a/align_app/adm/decider/client.py
+++ b/align_app/adm/decider/client.py
@@ -4,6 +4,7 @@ Provides a convenient get_decision() function that manages a singleton Multiproc
 """
 
 import atexit
+from typing import Dict, Any
 from align_utils.models import ADMResult
 from .decider import MultiprocessDecider
 from .types import DeciderParams
@@ -17,6 +18,12 @@ def _get_process_manager():
     if _decider is None:
         _decider = MultiprocessDecider()
     return _decider
+
+
+async def is_model_cached(resolved_config: Dict[str, Any]) -> bool:
+    """Check if model for this config is already loaded in worker."""
+    process_manager = _get_process_manager()
+    return await process_manager.is_model_cached(resolved_config)
 
 
 async def get_decision(params: DeciderParams) -> ADMResult:

--- a/align_app/adm/decider/decider.py
+++ b/align_app/adm/decider/decider.py
@@ -1,6 +1,7 @@
+from typing import Dict, Any
 from align_utils.models import ADMResult
 from .types import DeciderParams
-from .worker import decider_worker_func
+from .worker import decider_worker_func, CacheQuery, CacheQueryResult
 from .multiprocess_worker import (
     WorkerHandle,
     create_worker,
@@ -12,6 +13,12 @@ from .multiprocess_worker import (
 class MultiprocessDecider:
     def __init__(self):
         self.worker: WorkerHandle = create_worker(decider_worker_func)
+
+    async def is_model_cached(self, resolved_config: Dict[str, Any]) -> bool:
+        self.worker, result = await send(self.worker, CacheQuery(resolved_config))
+        if isinstance(result, CacheQueryResult):
+            return result.is_cached
+        return False
 
     async def get_decision(self, params: DeciderParams) -> ADMResult:
         self.worker, result = await send(self.worker, params)

--- a/align_app/app/alerts_controller.py
+++ b/align_app/app/alerts_controller.py
@@ -5,10 +5,12 @@ from trame.decorators import TrameApp
 class AlertsController:
     def __init__(self, server):
         self.server = server
-        self.server.state.alert_messages = []
+        self.server.state.alert_message = ""
+        self.server.state.alert_visible = False
+        self.server.state.alert_timeout = -1
 
     def show(self, message: str, timeout: int = -1):
-        self.server.state.alert_messages = [
-            *self.server.state.alert_messages,
-            {"text": message, "timeout": timeout},
-        ]
+        with self.server.state:
+            self.server.state.alert_message = message
+            self.server.state.alert_timeout = timeout
+            self.server.state.alert_visible = True

--- a/align_app/app/alerts_controller.py
+++ b/align_app/app/alerts_controller.py
@@ -5,15 +5,10 @@ from trame.decorators import TrameApp
 class AlertsController:
     def __init__(self, server):
         self.server = server
-        self.server.state.alert_message = ""
-        self.server.state.alert_visible = False
-        self.server.state.alert_timeout = -1
+        self.server.state.alert_messages = []
 
     def show(self, message: str, timeout: int = -1):
-        with self.server.state:
-            self.server.state.alert_message = message
-            self.server.state.alert_timeout = timeout
-            self.server.state.alert_visible = True
-
-    def hide(self):
-        self.server.state.alert_visible = False
+        self.server.state.alert_messages = [
+            *self.server.state.alert_messages,
+            {"text": message, "timeout": timeout},
+        ]

--- a/align_app/app/runs_registry.py
+++ b/align_app/app/runs_registry.py
@@ -103,13 +103,6 @@ class RunsRegistry:
 
         return await self._execute_with_cache(run, probe.choices or [])
 
-    def has_cached_decision(self, run_id: str) -> bool:
-        run = runs_core.get_run(self._runs, run_id)
-        if not run:
-            return False
-        cache_key = run.compute_cache_key()
-        return runs_core.get_cached_decision(self._runs, cache_key) is not None
-
     def get_run(self, run_id: str) -> Optional[Run]:
         run = runs_core.get_run(self._runs, run_id)
         if run:

--- a/align_app/app/runs_state_adapter.py
+++ b/align_app/app/runs_state_adapter.py
@@ -617,11 +617,10 @@ class RunsStateAdapter:
             self._add_pending_cache_key(cache_key)
 
         is_cached = self.runs_registry.has_cached_decision(run_id)
-        if not is_cached:
-            self._alerts.show("Loading model...")
-            await self.server.network_completion
-
-        self._alerts.show("Making decision...")
+        if is_cached:
+            self._alerts.show("Deciding...")
+        else:
+            self._alerts.show("Loading model and deciding...")
         await self.server.network_completion
 
         try:

--- a/align_app/app/runs_state_adapter.py
+++ b/align_app/app/runs_state_adapter.py
@@ -6,6 +6,7 @@ from ..adm.run_models import Run
 from .runs_registry import RunsRegistry
 from .runs_table_filter import RunsTableFilter
 from ..adm.decider.types import DeciderParams
+from ..adm.decider import is_model_cached
 from ..adm.system_adm_discovery import discover_system_adms
 from ..utils.utils import get_id
 from .runs_presentation import extract_base_scenarios
@@ -616,8 +617,8 @@ class RunsStateAdapter:
         with self.state:
             self._add_pending_cache_key(cache_key)
 
-        is_cached = self.runs_registry.has_cached_decision(run_id)
-        if is_cached:
+        run = self.runs_registry.get_run(run_id)
+        if run and await is_model_cached(run.decider_params.resolved_config):
             self._alerts.show("Deciding...")
         else:
             self._alerts.show("Loading model and deciding...")

--- a/align_app/app/ui.py
+++ b/align_app/app/ui.py
@@ -1541,20 +1541,12 @@ class AlignLayout(SinglePageLayout):
                             )
 
             with layout.content:
-                with vuetify3.VSnackbar(
-                    v_model=("alert_visible", False),
-                    text=("alert_message", ""),
-                    location="bottom left",
+                vuetify3.VSnackbarQueue(
+                    v_model=("alert_messages", []),
+                    location="bottom right",
                     color="white",
-                    timeout=("alert_timeout", -1),
                     content_class="text-h6 font-weight-medium",
-                ):
-                    with vuetify3.Template(v_slot_actions=""):
-                        vuetify3.VBtn(
-                            icon="mdi-close",
-                            variant="text",
-                            click="alert_visible = false",
-                        )
+                )
                 html.Div(
                     v_html=(
                         "'<style>"

--- a/align_app/app/ui.py
+++ b/align_app/app/ui.py
@@ -1541,12 +1541,20 @@ class AlignLayout(SinglePageLayout):
                             )
 
             with layout.content:
-                vuetify3.VSnackbarQueue(
-                    v_model=("alert_messages", []),
+                with vuetify3.VSnackbar(
+                    v_model=("alert_visible", False),
+                    text=("alert_message", ""),
                     location="bottom right",
                     color="white",
+                    timeout=("alert_timeout", -1),
                     content_class="text-h6 font-weight-medium",
-                )
+                ):
+                    with vuetify3.Template(v_slot_actions=""):
+                        vuetify3.VBtn(
+                            icon="mdi-close",
+                            variant="text",
+                            click="alert_visible = false",
+                        )
                 html.Div(
                     v_html=(
                         "'<style>"


### PR DESCRIPTION
## Summary
- Replace VSnackbar with VSnackbarQueue to support multiple stacking notifications
- Move snackbar position from bottom-left to bottom-right
- Simplify AlertsController to push messages to a queue array

## Test plan
- [ ] Start the app and trigger multiple decisions in quick succession
- [ ] Verify notifications stack and display sequentially
- [ ] Verify notifications appear in bottom-right corner